### PR TITLE
Fix a memory leak.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -34,15 +34,22 @@
                                 containerId: $elm[0]
                             };
 
-                            var chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
-                            google.visualization.events.addListener(chartWrapper, 'ready', function () {
-                                $scope.chart.displayed = true;
-                            });
-                            google.visualization.events.addListener(chartWrapper, 'error', function (err) {
-                                console.log("Chart not displayed due to error: " + err.message);
-                            });
+                            if($scope.chartWrapper==null) {
+                            	$scope.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
+                                google.visualization.events.addListener(chartWrapper, 'ready', function () {
+                                    $scope.chart.displayed = true;
+                                });
+                                google.visualization.events.addListener(chartWrapper, 'error', function (err) {
+                                    console.log("Chart not displayed due to error: " + err.message);
+                                });
+                            }
+                            else {
+                            	$scope.chartWrapper.setDataTable(dataTable);
+                            	$scope.chartWrapper.setOptions($scope.chart.options);
+                            }
+                            	
                             $timeout(function () {
-                                chartWrapper.draw();
+                            	$scope.chartWrapper.draw();
                             });
                         }, 0, true);
                     }


### PR DESCRIPTION
Fix a memory leak. Only create the ChartWrapper once and store it in the current scope. When the data is updated, update the existing ChardWrapper and redraw it instead of creating and drawing a new one.  Without this, the browser will bog down after many refreshes.  The bug and the fix were tested in Chrome using timeline and profile heap snapshots.
