### PR TITLE
IE8 script.onLoad fix

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -9,6 +9,15 @@
 (function (document, window) {
     'use strict';
 
+	//http://stackoverflow.com/a/15437678
+	function ieLoadBugFix(scriptElement, callback){
+        if (scriptElement.readyState=='loaded' || scriptElement.readyState=='completed') {
+             callback();
+         }else {
+             setTimeout(function() {ieLoadBugFix(scriptElement, callback); }, 100);
+         }
+	}
+	
     function loadScript(url, callback) {
         var script = document.createElement('script');
         script.src = url;
@@ -16,6 +25,8 @@
         script.onerror = function () {
             throw Error('Error loading "' + url + '"');
         };
+		
+		ieLoadBugFix(script, callback);
 
         document.getElementsByTagName('head')[0].appendChild(script);
     }


### PR DESCRIPTION
A simple, not elegant, fix to show all the google charts in IE8
