### PR TITLE
Prevent chartWrapper from being called before defined in IE8.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -69,7 +69,10 @@
                     // Redraw the chart if the window is resized
                     $rootScope.$on('resizeMsg', function (e) {
                         $timeout(function () {
-                            $scope.chartWrapper.draw();
+                            // Not always defined yet in IE so check
+                            if($scope.chartWrapper) {
+                                $scope.chartWrapper.draw();
+                            }
                         });
                     });
 


### PR DESCRIPTION
Added check to ensure chartWrapper was defined prior to calling draw.  Only could reproduce issue in IE8 but this appears to fix it.
