### PR TITLE
Add "main" property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
     "name": "angular-google-chart",
     "version": "0.0.8",
+    "main": "./ng-google-chart.js",
     "homepage": "http://bouil.github.io/angular-google-chart/",
     "authors": [
         "Nicolas Bouillon <nicolas@bouil.org>",


### PR DESCRIPTION
Without the `main` property, Grunt will not automatically include the library when building with `grunt server` or `grunt build`.
