### PR TITLE
support for custom formatters in chart object

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -166,6 +166,12 @@
                                     applyFormat("color", google.visualization.ColorFormat, dataTable);
                                 }
 
+                                var customFormatters = $scope.chart.customFormatters;
+                                if (typeof(customFormatters) != 'undefined') {
+                                    for (name in customFormatters) {
+                                        applyFormat(name, customFormatters[name], dataTable);
+                                    }
+                                }
 
                                 var chartWrapperArgs = {
                                     chartType: $scope.chart.type,


### PR DESCRIPTION
With this change you can add field `customFormatters` to the chart object. 
It's a map from formatter name to its class.

Such formatters still need their options to be set in `formatters` section(under corresponding name).

Example configuration(coffeescript) 

```
$scope.chartSpace =
  type: "PieChart"
  options:
    title: gettext "Space distribution"
    legend: "none"
    pieSliceText: 'value'
  customFormatters:
    size: SizeFormatter
  formatters:
    size: [
      columnNum: 1
    ]
  ...
```

where `SizeFormatter` is a formatter class as per Google Charts' api.
