### PR TITLE
Improve IE compatibility for api load callback

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -60,15 +60,19 @@
 
             script.setAttribute('type', 'text/javascript');
             script.src = googleJsapiUrl;
+            
+            if (script.addEventListener) { // Standard browsers (including IE9+)
+                script.addEventListener('load', onLoad, false);
+            } else { // IE8 and below
+                script.onreadystatechange = function () {
+                    if (script.readyState === 'loaded' || script.readyState === 'complete') {
+                        script.onreadystatechange = null;
+                        onLoad();
+                    }
+                };
+            }
+            
             head.appendChild(script);
-
-            script.onreadystatechange = function () {
-                if (this.readyState == 'complete') {
-                    onLoad();
-                }
-            };
-
-            script.onload = onLoad;
 
             return apiReady.promise;
         }])


### PR DESCRIPTION
Use addEventListener as the standards-compliant method, which is available in IE9+. See: http://msdn.microsoft.com/en-us/library/ie/ff975245(v=vs.85).aspx

Since IE9 introduced support for the 'load' event, there was a possibility in the old code that both 'onreadystatechange' and 'onload' event handlers would fire, so we test whether addEventListener is available and only use one or the other. See: http://msdn.microsoft.com/en-us/library/ie/hh180173(v=vs.85).aspx

If we are using 'onreadystatechange', we also need to check for the 'loaded' status. The 'loaded' status sometimes fires instead of the 'complete' status. (I noticed IE8 would give the 'loaded' status if the script was not being loaded from the cache). See: http://www.nczonline.net/blog/2009/06/23/loading-javascript-without-blocking/

IE11 removes support for onreadystatechange. See: http://msdn.microsoft.com/en-us/library/ie/bg182625(v=vs.85).aspx
