### PR TITLE
upgrade to google chart 1.1 (release candidate)

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -12,7 +12,7 @@
     angular.module('googlechart', [])
 
         .constant('googleChartApiConfig', {
-            version: '1',
+            version: '1.1',
             optionalSettings: {
                 packages: ['corechart']
             }


### PR DESCRIPTION
The 1.1 version supports pointShape option. We need it in our project.
