### PR TITLE
Formatters will be recreated when options change.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -100,11 +100,15 @@
                         });
                     });
 
+                    // Keeps old formatter configuration to compare against
+                    $scope.oldChartFormatters = {};
+
                     function applyFormat(formatType, formatClass, dataTable) {
 
                         if (typeof($scope.chart.formatters[formatType]) != 'undefined') {
-                            if ($scope.formatters[formatType] == null) {
-                                $scope.formatters[formatType] = new Array();
+                            if (!angular.equals($scope.chart.formatters[formatType], $scope.oldChartFormatters[formatType])) {
+                                $scope.oldChartFormatters[formatType] = $scope.chart.formatters[formatType];
+                                $scope.formatters[formatType] = [];
 
                                 if (formatType === 'color') {
                                     for (var cIdx = 0; cIdx < $scope.chart.formatters[formatType].length; cIdx++) {


### PR DESCRIPTION
Previously, if you updated the configuration for a formatter after the chart was drawn, it would not create new formatter and instead use the cached instances. This should fix it.

If there are ideas for a better fix, that will be great, but this functionality is especially needed when using a DateFormatter and changing the data with the need to also change the pattern.
