### PR TITLE
docs : correct reference to chartObject

### DIFF
--- a/partials/fat.html
+++ b/partials/fat.html
@@ -75,6 +75,6 @@
     <h2>Usage</h2>
     <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{cssStyle}}"&gt;&lt;/div&gt;</pre>
     <h2>Setup</h2>
-    <pre>$scope.chart = {{chart|json}}</pre>
+    <pre>$scope.chartObject = {{chart|json}}</pre>
 
 </div>


### PR DESCRIPTION
Usage sample shows 'chartObject`. Setup shows creating a scope property of`chart`.  Update the scope property to match the usage sample.

Signed-off-by: Justin Noel github@calendee.com
