### PR TITLE
Use angular.isArray instead of Array.isArray.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -161,7 +161,7 @@
                                 var dataTable;
                                 if ($scope.chart.data instanceof google.visualization.DataTable)
                                     dataTable = $scope.chart.data;
-                                else if (Array.isArray($scope.chart.data))
+                                else if (angular.isArray($scope.chart.data))
                                     dataTable = google.visualization.arrayToDataTable($scope.chart.data);
                                 else
                                     dataTable = new google.visualization.DataTable($scope.chart.data, 0.5);


### PR DESCRIPTION
Array.isArray is ECMAScript 5.1, and unsupported by older versions of IE. Rather than polyfilling the functionality, we should just use angulars built-in function.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
