### PR TITLE
Ability to Define DataView Columns for Labels

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -173,7 +173,7 @@
                         if (!draw.triggered && ($scope.chart != undefined)) {
                             draw.triggered = true;
                             $timeout(function () {
-								if ($scope.chart.dataViewColumns) {
+                                if ($scope.chart.dataViewColumns) {
                                     var dataView = new google.visualization.DataView(google.visualization.arrayToDataTable($scope.chart.data));
                                     dataView.setColumns($scope.chart.dataViewColumns);
                                     $scope.chart.data = dataView;


### PR DESCRIPTION
In order to define labels, you have to create a dataView: https://developers.google.com/chart/interactive/docs/gallery/barchart#Labels

The change would allow you to set dataViewColumns on the directive's chart object in the same way: 

``` javascript
 chart.dataViewColumns = [0, 1,
                       {
                           calc: "stringify",
                           sourceColumn: 1,
                           type: "string",
                           role: "annotation"
                       }];
```

I can work on providing the funcitonality in a different way (perhaps another scope variable in the directive) if you think there's a better solution.
