### PR TITLE
Update Axes on change to chart type 'BarChart'

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -210,7 +210,11 @@
                                     });
                                 }
                                 else {
-                                    $scope.chartWrapper.setChartType($scope.chart.type);
+									if (($scope.chart.type !== 'BarChart' && $scope.chartWrapper.getChartType() === 'BarChart') ||
+										($scope.chart.type === 'BarChart' && $scope.chartWrapper.getChartType() !== 'BarChart')) {
+										$scope.chart.options.hAxis = [$scope.chart.options.vAxis, $scope.chart.options.vAxis = $scope.chart.options.hAxis][0];
+									}
+									$scope.chartWrapper.setChartType($scope.chart.type);
                                     $scope.chartWrapper.setDataTable($scope.chart.data);
                                     $scope.chartWrapper.setView($scope.chart.view);
                                     $scope.chartWrapper.setOptions($scope.chart.options);


### PR DESCRIPTION
Changing chart type to 'BarChart' in runtime does not updates the Axes.
when going from ColumnChart/AreaChart/.. to BarChart, the vAxis should
become into hAxis and vice-versa.

To solve this problem, in my commit, when switching to BarChart and the
previous type is different from Barchart, OR when switching to any other
type and the previous type is Barchart the Axes are exchanged!
