### PR TITLE
Adding ability to get multi-selects from a table chart.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -197,16 +197,16 @@
                                         console.log(err);
                                     });
                                     google.visualization.events.addListener($scope.chartWrapper, 'select', function () {
-                                        var p = {selectedItems:$scope.chartWrapper.getChart().getSelection()};
+                                        var selectEventRetParams = {selectedItems:$scope.chartWrapper.getChart().getSelection()};
                                         // This is for backwards compatibility for people using 'selectedItem' that only wanted the first selection.
-                                        p['selectedItem'] = p['selectedItems'][0];
+                                        selectEventRetParams['selectedItem'] = selectEventRetParams['selectedItems'][0];
                                         $scope.$apply(function () {
                                             if ($attrs.select) {
                                                 console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
-                                                $scope.select(p);
+                                                $scope.select(selectEventRetParams);
                                             }
                                             else {
-                                                $scope.onSelect(p);
+                                                $scope.onSelect(selectEventRetParams);
                                             }
                                         });
                                     });


### PR DESCRIPTION
When I use a 'Table' type chart, google allows multi-select and by returning the first object it was disallowed. 

I added selectedItems and return all the selectedItems. I also left the functionality intact for selectedItem so it won't break people already using this functionality.
