### PR TITLE
Bugfix on select return

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -203,10 +203,10 @@
                                         $scope.$apply(function () {
                                             if ($attrs.select) {
                                                 console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
-                                                $scope.select(selectEventRetParams);
+                                                $scope.select({selectEventRetParams: selectEventRetParams});
                                             }
                                             else {
-                                                $scope.onSelect(selectEventRetParams);
+                                                $scope.onSelect({selectEventRetParams: selectEventRetParams});
                                             }
                                         });
                                     });


### PR DESCRIPTION
As far as I know, it does not work without this change. Also it would be a nice idea, to return the wrapper-object as whole, because sometimes you would want to change it?
