### PR TITLE
Format manager

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -8,6 +8,7 @@
  */
  
  /* global google */
+ /* jshint -W072 */
  
 (function (document, window, angular) {
     'use strict';
@@ -42,32 +43,34 @@
                         return;
                     }
                     for (formatType in tFormats){
-                        FormatClass = getFormatClass(formatType);
-                        if (!angular.isFunction(FormatClass)){
-                            // if no class constructor was returned,
-                            // there's no point in completing cycle
-                            continue;
-                        }
-                        if (angular.isArray(tFormats[formatType])) {
-                            // basic change detection; no need to run if no changes
-                            if (!angular.equals(tFormats[formatType], oldFormatTemplates[formatType])) {
-                                oldFormatTemplates[formatType] = tFormats[formatType];
-                                self.iFormats[formatType] = [];
-    
-                                if (formatType === 'color') {
-                                    instantiateColorFormatters(tFormats);
-                                } else {
-                                    for (i = 0; i < tFormats[formatType].length; i++) {
-                                        self.iFormats[formatType].push(new FormatClass(
-                                            tFormats[formatType][i])
-                                        );
+                        if (tFormats.hasOwnProperty(formatType)){
+                            FormatClass = getFormatClass(formatType);
+                            if (!angular.isFunction(FormatClass)){
+                                // if no class constructor was returned,
+                                // there's no point in completing cycle
+                                continue;
+                            }
+                            if (angular.isArray(tFormats[formatType])) {
+                                // basic change detection; no need to run if no changes
+                                if (!angular.equals(tFormats[formatType], oldFormatTemplates[formatType])) {
+                                    oldFormatTemplates[formatType] = tFormats[formatType];
+                                    self.iFormats[formatType] = [];
+        
+                                    if (formatType === 'color') {
+                                        instantiateColorFormatters(tFormats);
+                                    } else {
+                                        for (i = 0; i < tFormats[formatType].length; i++) {
+                                            self.iFormats[formatType].push(new FormatClass(
+                                                tFormats[formatType][i])
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                            
-                            //Many formatters require HTML tags to display special formatting
-                            if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color') {
-                                requiresHtml = true;
+                                
+                                //Many formatters require HTML tags to display special formatting
+                                if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color') {
+                                    requiresHtml = true;
+                                }
                             }
                         }
                     }

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -94,20 +94,6 @@
                     }
                 }
                 
-                // helper function that gets a list of all the loaded formatter class names
-                // not used, yet.
-                function listFormatters(){
-                    var formatNames = []
-                    for (var prop in google.visualization){
-                        if(google.visualization.hasOwnProperty(prop)){
-                            if(prop.indexOf("Format", prop.length - ("Format").length) !== -1){
-                                formatNames.push(prop);
-                            }
-                        }
-                    }
-                    return formatNames;
-                }
-                
                 function getFormatClass(formatType){
                     var className = formatType.charAt(0).toUpperCase() + formatType.slice(1).toLowerCase() + "Format";
                     if (google.visualization.hasOwnProperty(className)){


### PR DESCRIPTION
Cleans up the `GoogleChartController` a little bit by breaking out formatter logic into it's own JavaScript class, as per #177.

Increases the overall size of the ng-google-chart.js file, but makes the methods in the `GoogleChartController` a lot easier to read for someone who doesn't already know what's going on.  Once we get a build system in place, Lines of Code won't be such an issue anymore.