### PR TITLE
Add "Github Contributors" as author.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,8 +10,7 @@ module.exports = function(grunt) {
             '/*\n' +
             '* @description Google Chart Api Directive Module for AngularJS\n' +
             '* @version <%= pkg.version %>\n' +
-            '* @author Nicolas Bouillon <nicolas@bouil.org>\n' +
-            '* @author GitHub contributors\n' +
+            '* @author GitHub Contributors <https://github.com/angular-google-chart/angular-google-chart/graphs/contributors> \n' +
             '* @license MIT\n' +
             '* @year 2013\n' +
             '*/\n',
@@ -26,8 +25,7 @@ module.exports = function(grunt) {
             '/*\n' +
             '* @description Google Chart Api Directive Module for AngularJS\n' +
             '* @version <%= pkg.version %>\n' +
-            '* @author Nicolas Bouillon <nicolas@bouil.org>\n' +
-            '* @author GitHub contributors\n' +
+            '* @author GitHub Contributors <https://github.com/angular-google-chart/angular-google-chart/graphs/contributors> \n' +
             '* @license MIT\n' +
             '* @year 2013\n' +
             '*/\n'

--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,7 @@
     },
     "description": "Google Chart Tools AngularJS Directive Module",
     "authors": [
-        "Nicolas Bouillon <nicolas@bouil.org>",
-        "GitHub Contributors"
+        "GitHub Contributors <https://github.com/angular-google-chart/angular-google-chart/graphs/contributors>"
     ],
     "keywords": [
         "angular",

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -2,8 +2,7 @@
 /*
 * @description Google Chart Api Directive Module for AngularJS
 * @version 0.1.0-beta.1
-* @author Nicolas Bouillon <nicolas@bouil.org>
-* @author GitHub contributors
+* @author GitHub Contributors <https://github.com/angular-google-chart/angular-google-chart/graphs/contributors>
 * @license MIT
 * @year 2013
 */
@@ -809,3 +808,4 @@
         };
     }
 })();
+

--- a/package.json
+++ b/package.json
@@ -8,15 +8,10 @@
     "type": "git",
     "url": "https://github.com/angular-google-chart/angular-google-chart.git"
   },
-  "author": {
-    "name": "Nicolas Bouillon",
-    "email": "nicolas@bouil.org"
-  },
   "contributors": [
     {
-      "name": "Nicholas Bering",
-      "email": "nulllifeexception@gmail.com",
-      "url": "http://nicholasbering.ca"
+      "name": "Github Contributors",
+      "url": "https://github.com/angular-google-chart/angular-google-chart/graphs/contributors"
     }
   ],
   "keywords": [


### PR DESCRIPTION
I was thinking to add @Balrog30 in the author list, but I though it would be better to redirect to the contributor list of the repository, where we can easily see who contribute to the project.

(And removing my email address has also a good side effect: some people are mailing me directly instead of opening a Github issue)