### PR TITLE
Optional optional settings :)

### DIFF
--- a/src/googleChartApiPromise.js
+++ b/src/googleChartApiPromise.js
@@ -6,7 +6,7 @@
     googleChartApiPromiseFactory.$inject = ['$rootScope', '$q', 'googleChartApiConfig', 'googleJsapiUrl'];
         
     function googleChartApiPromiseFactory($rootScope, $q, apiConfig, googleJsapiUrl) {
-	apiConfig.optionalSettings = apiConfig.optionalSettings || {};
+        apiConfig.optionalSettings = apiConfig.optionalSettings || {};
         var apiReady = $q.defer();
         var onLoad = function () {
             // override callback function

--- a/src/googleChartApiPromise.js
+++ b/src/googleChartApiPromise.js
@@ -6,6 +6,7 @@
     googleChartApiPromiseFactory.$inject = ['$rootScope', '$q', 'googleChartApiConfig', 'googleJsapiUrl'];
         
     function googleChartApiPromiseFactory($rootScope, $q, apiConfig, googleJsapiUrl) {
+	apiConfig.optionalSettings = apiConfig.optionalSettings || {};
         var apiReady = $q.defer();
         var onLoad = function () {
             // override callback function


### PR DESCRIPTION
Let's say the user of this library only wants to configure the used version of Google Charts to be 1.1. It is done by overriding the googleChartApiConfig value within the actual app that uses this library.
So you'd go in this manner (as already suggested in the docs):
```
angular.module('google-chart-sample')
  .value('googleChartApiConfig', {
    version: '1.1'
  });
```

The problem is that this case will cause a runtime failure in googleChartApiPromise.js, concretely at the line at https://github.com/angular-google-chart/angular-google-chart/blob/0.1.0-beta.2/src/googleChartApiPromise.js#L14
```
var oldCb = apiConfig.optionalSettings.callback;
```

This pull request simply makes sure that apiConfig.optionalSettings is set to {} in case the override has not defined it. oldCb will therefore be assigned a value of undefined, which is afterwards handled as it should.