### PR TITLE
moving chartObject to myChartObject for consistency with other angular documentation

### DIFF
--- a/_docs/0.0.11/directives/googleChart.md
+++ b/_docs/0.0.11/directives/googleChart.md
@@ -20,7 +20,7 @@ for practical code examples.
         <td><p><code>chart</code></p>
         <td>expression</td>
         <td>Binding to the chart object with the values needed to build the chart.</td>
-        <td><p><code>chart="chartObject"</code></p></td>
+        <td><p><code>chart="myChartObject"</code></p></td>
     </tr>
     <tr>
         <td><p><code>on-select</code></p></td>

--- a/_docs/0.0.11/examples/annotation.html
+++ b/_docs/0.0.11/examples/annotation.html
@@ -14,11 +14,11 @@ ng-app: "google-chart-sample"
     <input type="number" ng-model="secondRow[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/annotation.js
+++ b/_docs/0.0.11/examples/annotation.js
@@ -2,7 +2,7 @@
 (function(){
     angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
     .controller("AnnotationChartCtrl", function ($scope) {
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         $scope.secondRow = [
             {v: new Date(2314, 2, 16)},
@@ -15,9 +15,9 @@
         ];
 
 
-        $scope.chartObject.type = "AnnotationChart";
+        $scope.myChartObject.type = "AnnotationChart";
 
-        $scope.chartObject.data = {"cols": [
+        $scope.myChartObject.data = {"cols": [
             {id: "month", label: "Month", type: "date"},
             {id: "kepler-data", label: "Kepler-22b mission", type: "number"},
             {id: "kepler-annot", label: "Kepler-22b Annotation Title", type: "string"},
@@ -48,7 +48,7 @@
             ]}
         ]};
 
-        $scope.chartObject.options = {
+        $scope.myChartObject.options = {
             displayAnnotations: true
         };
     });

--- a/_docs/0.0.11/examples/bar.html
+++ b/_docs/0.0.11/examples/bar.html
@@ -13,11 +13,11 @@ ng-controller: "GenericChartCtrl"
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/bar.js
+++ b/_docs/0.0.11/examples/bar.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "BarChart";
+    $scope.myChartObject.type = "BarChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.0.11/examples/column.html
+++ b/_docs/0.0.11/examples/column.html
@@ -9,17 +9,17 @@ scripts:
 ng-app: "google-chart-sample"
 ng-controller: "GenericChartCtrl"
 ---
-<div ng-init="chartObject.type='ColumnChart'">
+<div ng-init="myChartObject.type='ColumnChart'">
 <div>
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 </div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/column.js
+++ b/_docs/0.0.11/examples/column.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "ColumnChart";
+    $scope.myChartObject.type = "ColumnChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.0.11/examples/gauge.html
+++ b/_docs/0.0.11/examples/gauge.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "GaugeChartCtrl"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/gauge.js
+++ b/_docs/0.0.11/examples/gauge.js
@@ -4,10 +4,10 @@
   angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
   .controller("GaugeChartCtrl", function($scope) {
 
-    $scope.chartObject = {};
-    $scope.chartObject.type = "Gauge";
+    $scope.myChartObject = {};
+    $scope.myChartObject.type = "Gauge";
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
       width: 400,
       height: 120,
       redFrom: 90,
@@ -17,7 +17,7 @@
       minorTicks: 5
     };
 
-    $scope.chartObject.data = [
+    $scope.myChartObject.data = [
       ['Label', 'Value'],
       ['Memory', 80],
       ['CPU', 55],

--- a/_docs/0.0.11/examples/hide-series.html
+++ b/_docs/0.0.11/examples/hide-series.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "HideSeriesController"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 <div class="alert alert-info"><span class="fa fa-info-circle fa-lg"></span> Click a legend item to toggle a series.</div>
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/hide-series.js
+++ b/_docs/0.0.11/examples/hide-series.js
@@ -7,7 +7,7 @@
 
     function HideSeriesController($scope) {
         // Properties
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         //Methods
         $scope.hideSeries = hideSeries;
@@ -17,27 +17,27 @@
         function hideSeries(selectedItem) {
             var col = selectedItem.column;
             if (selectedItem.row === null) {
-                if ($scope.chartObject.view.columns[col] == col) {
-                    $scope.chartObject.view.columns[col] = {
-                        label: $scope.chartObject.data.cols[col].label,
-                        type: $scope.chartObject.data.cols[col].type,
+                if ($scope.myChartObject.view.columns[col] == col) {
+                    $scope.myChartObject.view.columns[col] = {
+                        label: $scope.myChartObject.data.cols[col].label,
+                        type: $scope.myChartObject.data.cols[col].type,
                         calc: function() {
                             return null;
                         }
                     };
-                    $scope.chartObject.options.colors[col - 1] = '#CCCCCC';
+                    $scope.myChartObject.options.colors[col - 1] = '#CCCCCC';
                 }
                 else {
-                    $scope.chartObject.view.columns[col] = col;
-                    $scope.chartObject.options.colors[col - 1] = $scope.chartObject.options.defaultColors[col - 1];
+                    $scope.myChartObject.view.columns[col] = col;
+                    $scope.myChartObject.options.colors[col - 1] = $scope.myChartObject.options.defaultColors[col - 1];
                 }
             }
         }
 
         function init() {
-            $scope.chartObject.type = "LineChart";
-            $scope.chartObject.displayed = false;
-            $scope.chartObject.data = {
+            $scope.myChartObject.type = "LineChart";
+            $scope.myChartObject.displayed = false;
+            $scope.myChartObject.data = {
                 "cols": [{
                     id: "month",
                     label: "Month",
@@ -102,7 +102,7 @@
                     }]
                 }]
             };
-            $scope.chartObject.options = {
+            $scope.myChartObject.options = {
                 "title": "Sales per month",
                 "colors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
                 "defaultColors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
@@ -120,7 +120,7 @@
                 }
             };
 
-            $scope.chartObject.view = {
+            $scope.myChartObject.view = {
                 columns: [0, 1, 2, 3, 4]
             };
         }

--- a/_docs/0.0.11/examples/multi-chart.html
+++ b/_docs/0.0.11/examples/multi-chart.html
@@ -80,9 +80,9 @@ ng-controller: "MultiChartCtrl"
     <div class="col-xs-12">
 
         <h2>Usage</h2>
-        <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
+        <pre ng-non-bindable>&lt;div google-chart chart="myChartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
         <h2>Setup</h2>
-        <pre>$scope.chartObject = !! chart|json:true !!</pre>
+        <pre>$scope.myChartObject = !! chart|json:true !!</pre>
 
     </div>
 </div>

--- a/_docs/0.0.11/examples/pie.html
+++ b/_docs/0.0.11/examples/pie.html
@@ -13,11 +13,11 @@ ng-controller: GenericChartCtrl
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.0.11/examples/pie.js
+++ b/_docs/0.0.11/examples/pie.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "PieChart";
+    $scope.myChartObject.type = "PieChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.0.11/services/googleChartApiPromise.md
+++ b/_docs/0.0.11/services/googleChartApiPromise.md
@@ -19,14 +19,14 @@ objects and functions related to the API will not be available.
     ExampleController.$inject = ['$scope', 'googleChartApiPromise'];
 
     function ExampleController ($scope, googleChartApiPromise){
-        $scope.chartObject = {
+        $scope.myChartObject = {
             type: 'PieChart'
         };
 
         googleChartApiPromise.then(buildDataTable);
 
         function buildDataTable(){
-            $scope.chartObject.data = new google.visualization.DataTable();
+            $scope.myChartObject.data = new google.visualization.DataTable();
             // Continue building the data table.
         }
     }

--- a/_docs/0.1.0-beta.1/directives/agcOnError.html
+++ b/_docs/0.1.0-beta.1/directives/agcOnError.html
@@ -22,7 +22,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-error="errorHandler(message)"></div>
+<div google-chart chart="myChartObject" agc-on-error="errorHandler(message)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0-beta.1/directives/agcOnMouseout.md
+++ b/_docs/0.1.0-beta.1/directives/agcOnMouseout.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
+<div google-chart chart="myChartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0-beta.1/directives/agcOnReady.md
+++ b/_docs/0.1.0-beta.1/directives/agcOnReady.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0-beta.1/directives/agcOnSelect.html
+++ b/_docs/0.1.0-beta.1/directives/agcOnSelect.html
@@ -27,7 +27,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="selectHandler(selectedItem)"></div>
+<div google-chart chart="myChartObject" agc-on-select="selectHandler(selectedItem)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0-beta.1/directives/googleChart.md
+++ b/_docs/0.1.0-beta.1/directives/googleChart.md
@@ -20,7 +20,7 @@ for practical code examples.
         <td><p><code>chart</code></p>
         <td>expression</td>
         <td>Binding to the chart object with the values needed to build the chart.</td>
-        <td><p><code>chart="chartObject"</code></p></td>
+        <td><p><code>chart="myChartObject"</code></p></td>
     </tr>
     <tr>
         <td><p><code>before-draw</code></p></td>

--- a/_docs/0.1.0-beta.1/examples/annotation.html
+++ b/_docs/0.1.0-beta.1/examples/annotation.html
@@ -14,11 +14,11 @@ ng-app: "google-chart-sample"
     <input type="number" ng-model="secondRow[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/annotation.js
+++ b/_docs/0.1.0-beta.1/examples/annotation.js
@@ -2,7 +2,7 @@
 (function(){
     angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
     .controller("AnnotationChartCtrl", function ($scope) {
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         $scope.secondRow = [
             {v: new Date(2314, 2, 16)},
@@ -15,9 +15,9 @@
         ];
 
 
-        $scope.chartObject.type = "AnnotationChart";
+        $scope.myChartObject.type = "AnnotationChart";
 
-        $scope.chartObject.data = {"cols": [
+        $scope.myChartObject.data = {"cols": [
             {id: "month", label: "Month", type: "date"},
             {id: "kepler-data", label: "Kepler-22b mission", type: "number"},
             {id: "kepler-annot", label: "Kepler-22b Annotation Title", type: "string"},
@@ -48,7 +48,7 @@
             ]}
         ]};
 
-        $scope.chartObject.options = {
+        $scope.myChartObject.options = {
             displayAnnotations: true
         };
     });

--- a/_docs/0.1.0-beta.1/examples/bar.html
+++ b/_docs/0.1.0-beta.1/examples/bar.html
@@ -13,11 +13,11 @@ ng-controller: "GenericChartCtrl"
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/bar.js
+++ b/_docs/0.1.0-beta.1/examples/bar.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "BarChart";
+    $scope.myChartObject.type = "BarChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.1/examples/column.html
+++ b/_docs/0.1.0-beta.1/examples/column.html
@@ -9,17 +9,17 @@ scripts:
 ng-app: "google-chart-sample"
 ng-controller: "GenericChartCtrl"
 ---
-<div ng-init="chartObject.type='ColumnChart'">
+<div ng-init="myChartObject.type='ColumnChart'">
 <div>
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 </div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/column.js
+++ b/_docs/0.1.0-beta.1/examples/column.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "ColumnChart";
+    $scope.myChartObject.type = "ColumnChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.1/examples/gauge.html
+++ b/_docs/0.1.0-beta.1/examples/gauge.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "GaugeChartCtrl"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/gauge.js
+++ b/_docs/0.1.0-beta.1/examples/gauge.js
@@ -4,10 +4,10 @@
   angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
   .controller("GaugeChartCtrl", function($scope) {
 
-    $scope.chartObject = {};
-    $scope.chartObject.type = "Gauge";
+    $scope.myChartObject = {};
+    $scope.myChartObject.type = "Gauge";
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
       width: 400,
       height: 120,
       redFrom: 90,
@@ -17,7 +17,7 @@
       minorTicks: 5
     };
 
-    $scope.chartObject.data = [
+    $scope.myChartObject.data = [
       ['Label', 'Value'],
       ['Memory', 80],
       ['CPU', 55],

--- a/_docs/0.1.0-beta.1/examples/hide-series.html
+++ b/_docs/0.1.0-beta.1/examples/hide-series.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "HideSeriesController"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 <div class="alert alert-info"><span class="fa fa-info-circle fa-lg"></span> Click a legend item to toggle a series.</div>
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/hide-series.js
+++ b/_docs/0.1.0-beta.1/examples/hide-series.js
@@ -7,7 +7,7 @@
 
     function HideSeriesController($scope) {
         // Properties
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         //Methods
         $scope.hideSeries = hideSeries;
@@ -17,27 +17,27 @@
         function hideSeries(selectedItem) {
             var col = selectedItem.column;
             if (selectedItem.row === null) {
-                if ($scope.chartObject.view.columns[col] == col) {
-                    $scope.chartObject.view.columns[col] = {
-                        label: $scope.chartObject.data.cols[col].label,
-                        type: $scope.chartObject.data.cols[col].type,
+                if ($scope.myChartObject.view.columns[col] == col) {
+                    $scope.myChartObject.view.columns[col] = {
+                        label: $scope.myChartObject.data.cols[col].label,
+                        type: $scope.myChartObject.data.cols[col].type,
                         calc: function() {
                             return null;
                         }
                     };
-                    $scope.chartObject.options.colors[col - 1] = '#CCCCCC';
+                    $scope.myChartObject.options.colors[col - 1] = '#CCCCCC';
                 }
                 else {
-                    $scope.chartObject.view.columns[col] = col;
-                    $scope.chartObject.options.colors[col - 1] = $scope.chartObject.options.defaultColors[col - 1];
+                    $scope.myChartObject.view.columns[col] = col;
+                    $scope.myChartObject.options.colors[col - 1] = $scope.myChartObject.options.defaultColors[col - 1];
                 }
             }
         }
 
         function init() {
-            $scope.chartObject.type = "LineChart";
-            $scope.chartObject.displayed = false;
-            $scope.chartObject.data = {
+            $scope.myChartObject.type = "LineChart";
+            $scope.myChartObject.displayed = false;
+            $scope.myChartObject.data = {
                 "cols": [{
                     id: "month",
                     label: "Month",
@@ -102,7 +102,7 @@
                     }]
                 }]
             };
-            $scope.chartObject.options = {
+            $scope.myChartObject.options = {
                 "title": "Sales per month",
                 "colors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
                 "defaultColors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
@@ -120,7 +120,7 @@
                 }
             };
 
-            $scope.chartObject.view = {
+            $scope.myChartObject.view = {
                 columns: [0, 1, 2, 3, 4]
             };
         }

--- a/_docs/0.1.0-beta.1/examples/multi-chart.html
+++ b/_docs/0.1.0-beta.1/examples/multi-chart.html
@@ -80,9 +80,9 @@ ng-controller: "MultiChartCtrl"
     <div class="col-xs-12">
 
         <h2>Usage</h2>
-        <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
+        <pre ng-non-bindable>&lt;div google-chart chart="myChartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
         <h2>Setup</h2>
-        <pre>$scope.chartObject = !! chart|json:true !!</pre>
+        <pre>$scope.myChartObject = !! chart|json:true !!</pre>
 
     </div>
 </div>

--- a/_docs/0.1.0-beta.1/examples/pie.html
+++ b/_docs/0.1.0-beta.1/examples/pie.html
@@ -13,11 +13,11 @@ ng-controller: GenericChartCtrl
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.1/examples/pie.js
+++ b/_docs/0.1.0-beta.1/examples/pie.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "PieChart";
+    $scope.myChartObject.type = "PieChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.1/services/googleChartApiPromise.md
+++ b/_docs/0.1.0-beta.1/services/googleChartApiPromise.md
@@ -19,14 +19,14 @@ objects and functions related to the API will not be available.
     ExampleController.$inject = ['$scope', 'googleChartApiPromise'];
 
     function ExampleController ($scope, googleChartApiPromise){
-        $scope.chartObject = {
+        $scope.myChartObject = {
             type: 'PieChart'
         };
 
         googleChartApiPromise.then(buildDataTable);
 
         function buildDataTable(){
-            $scope.chartObject.data = new google.visualization.DataTable();
+            $scope.myChartObject.data = new google.visualization.DataTable();
             // Continue building the data table.
         }
     }

--- a/_docs/0.1.0-beta.2/directives/agcBeforeDraw.md
+++ b/_docs/0.1.0-beta.2/directives/agcBeforeDraw.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0-beta.2/directives/agcOnError.html
+++ b/_docs/0.1.0-beta.2/directives/agcOnError.html
@@ -22,7 +22,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-error="errorHandler(message)"></div>
+<div google-chart chart="myChartObject" agc-on-error="errorHandler(message)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0-beta.2/directives/agcOnMouseout.md
+++ b/_docs/0.1.0-beta.2/directives/agcOnMouseout.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
+<div google-chart chart="myChartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0-beta.2/directives/agcOnReady.md
+++ b/_docs/0.1.0-beta.2/directives/agcOnReady.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0-beta.2/directives/agcOnSelect.html
+++ b/_docs/0.1.0-beta.2/directives/agcOnSelect.html
@@ -27,7 +27,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="selectHandler(selectedItem)"></div>
+<div google-chart chart="myChartObject" agc-on-select="selectHandler(selectedItem)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0-beta.2/directives/googleChart.md
+++ b/_docs/0.1.0-beta.2/directives/googleChart.md
@@ -20,6 +20,6 @@ for practical code examples.
         <td><p><code>chart</code></p>
         <td>expression</td>
         <td>Binding to the chart object with the values needed to build the chart.</td>
-        <td><p><code>chart="chartObject"</code></p></td>
+        <td><p><code>chart="myChartObject"</code></p></td>
     </tr>
 </table>

--- a/_docs/0.1.0-beta.2/examples/annotation.html
+++ b/_docs/0.1.0-beta.2/examples/annotation.html
@@ -14,11 +14,11 @@ ng-app: "google-chart-sample"
     <input type="number" ng-model="secondRow[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/annotation.js
+++ b/_docs/0.1.0-beta.2/examples/annotation.js
@@ -2,7 +2,7 @@
 (function(){
     angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
     .controller("AnnotationChartCtrl", function ($scope) {
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         $scope.secondRow = [
             {v: new Date(2314, 2, 16)},
@@ -15,9 +15,9 @@
         ];
 
 
-        $scope.chartObject.type = "AnnotationChart";
+        $scope.myChartObject.type = "AnnotationChart";
 
-        $scope.chartObject.data = {"cols": [
+        $scope.myChartObject.data = {"cols": [
             {id: "month", label: "Month", type: "date"},
             {id: "kepler-data", label: "Kepler-22b mission", type: "number"},
             {id: "kepler-annot", label: "Kepler-22b Annotation Title", type: "string"},
@@ -48,7 +48,7 @@
             ]}
         ]};
 
-        $scope.chartObject.options = {
+        $scope.myChartObject.options = {
             displayAnnotations: true
         };
     });

--- a/_docs/0.1.0-beta.2/examples/bar.html
+++ b/_docs/0.1.0-beta.2/examples/bar.html
@@ -13,11 +13,11 @@ ng-controller: "GenericChartCtrl"
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/bar.js
+++ b/_docs/0.1.0-beta.2/examples/bar.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "BarChart";
+    $scope.myChartObject.type = "BarChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.2/examples/column.html
+++ b/_docs/0.1.0-beta.2/examples/column.html
@@ -9,17 +9,17 @@ scripts:
 ng-app: "google-chart-sample"
 ng-controller: "GenericChartCtrl"
 ---
-<div ng-init="chartObject.type='ColumnChart'">
+<div ng-init="myChartObject.type='ColumnChart'">
 <div>
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 </div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/column.js
+++ b/_docs/0.1.0-beta.2/examples/column.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "ColumnChart";
+    $scope.myChartObject.type = "ColumnChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.2/examples/gauge.html
+++ b/_docs/0.1.0-beta.2/examples/gauge.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "GaugeChartCtrl"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/gauge.js
+++ b/_docs/0.1.0-beta.2/examples/gauge.js
@@ -4,10 +4,10 @@
   angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
   .controller("GaugeChartCtrl", function($scope) {
 
-    $scope.chartObject = {};
-    $scope.chartObject.type = "Gauge";
+    $scope.myChartObject = {};
+    $scope.myChartObject.type = "Gauge";
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
       width: 400,
       height: 120,
       redFrom: 90,
@@ -17,7 +17,7 @@
       minorTicks: 5
     };
 
-    $scope.chartObject.data = [
+    $scope.myChartObject.data = [
       ['Label', 'Value'],
       ['Memory', 80],
       ['CPU', 55],

--- a/_docs/0.1.0-beta.2/examples/hide-series.html
+++ b/_docs/0.1.0-beta.2/examples/hide-series.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "HideSeriesController"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 <div class="alert alert-info"><span class="fa fa-info-circle fa-lg"></span> Click a legend item to toggle a series.</div>
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/hide-series.js
+++ b/_docs/0.1.0-beta.2/examples/hide-series.js
@@ -7,7 +7,7 @@
 
     function HideSeriesController($scope) {
         // Properties
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         //Methods
         $scope.hideSeries = hideSeries;
@@ -17,27 +17,27 @@
         function hideSeries(selectedItem) {
             var col = selectedItem.column;
             if (selectedItem.row === null) {
-                if ($scope.chartObject.view.columns[col] == col) {
-                    $scope.chartObject.view.columns[col] = {
-                        label: $scope.chartObject.data.cols[col].label,
-                        type: $scope.chartObject.data.cols[col].type,
+                if ($scope.myChartObject.view.columns[col] == col) {
+                    $scope.myChartObject.view.columns[col] = {
+                        label: $scope.myChartObject.data.cols[col].label,
+                        type: $scope.myChartObject.data.cols[col].type,
                         calc: function() {
                             return null;
                         }
                     };
-                    $scope.chartObject.options.colors[col - 1] = '#CCCCCC';
+                    $scope.myChartObject.options.colors[col - 1] = '#CCCCCC';
                 }
                 else {
-                    $scope.chartObject.view.columns[col] = col;
-                    $scope.chartObject.options.colors[col - 1] = $scope.chartObject.options.defaultColors[col - 1];
+                    $scope.myChartObject.view.columns[col] = col;
+                    $scope.myChartObject.options.colors[col - 1] = $scope.myChartObject.options.defaultColors[col - 1];
                 }
             }
         }
 
         function init() {
-            $scope.chartObject.type = "LineChart";
-            $scope.chartObject.displayed = false;
-            $scope.chartObject.data = {
+            $scope.myChartObject.type = "LineChart";
+            $scope.myChartObject.displayed = false;
+            $scope.myChartObject.data = {
                 "cols": [{
                     id: "month",
                     label: "Month",
@@ -102,7 +102,7 @@
                     }]
                 }]
             };
-            $scope.chartObject.options = {
+            $scope.myChartObject.options = {
                 "title": "Sales per month",
                 "colors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
                 "defaultColors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
@@ -120,7 +120,7 @@
                 }
             };
 
-            $scope.chartObject.view = {
+            $scope.myChartObject.view = {
                 columns: [0, 1, 2, 3, 4]
             };
         }

--- a/_docs/0.1.0-beta.2/examples/multi-chart.html
+++ b/_docs/0.1.0-beta.2/examples/multi-chart.html
@@ -80,9 +80,9 @@ ng-controller: "MultiChartCtrl"
     <div class="col-xs-12">
 
         <h2>Usage</h2>
-        <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
+        <pre ng-non-bindable>&lt;div google-chart chart="myChartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
         <h2>Setup</h2>
-        <pre>$scope.chartObject = !! chart|json:true !!</pre>
+        <pre>$scope.myChartObject = !! chart|json:true !!</pre>
 
     </div>
 </div>

--- a/_docs/0.1.0-beta.2/examples/pie.html
+++ b/_docs/0.1.0-beta.2/examples/pie.html
@@ -13,11 +13,11 @@ ng-controller: GenericChartCtrl
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0-beta.2/examples/pie.js
+++ b/_docs/0.1.0-beta.2/examples/pie.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "PieChart";
+    $scope.myChartObject.type = "PieChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0-beta.2/services/googleChartApiPromise.md
+++ b/_docs/0.1.0-beta.2/services/googleChartApiPromise.md
@@ -19,14 +19,14 @@ objects and functions related to the API will not be available.
     ExampleController.$inject = ['$scope', 'googleChartApiPromise'];
 
     function ExampleController ($scope, googleChartApiPromise){
-        $scope.chartObject = {
+        $scope.myChartObject = {
             type: 'PieChart'
         };
 
         googleChartApiPromise.then(buildDataTable);
 
         function buildDataTable(){
-            $scope.chartObject.data = new google.visualization.DataTable();
+            $scope.myChartObject.data = new google.visualization.DataTable();
             // Continue building the data table.
         }
     }

--- a/_docs/0.1.0/directives/agcBeforeDraw.md
+++ b/_docs/0.1.0/directives/agcBeforeDraw.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0/directives/agcOnError.html
+++ b/_docs/0.1.0/directives/agcOnError.html
@@ -22,7 +22,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-error="errorHandler(message)"></div>
+<div google-chart chart="myChartObject" agc-on-error="errorHandler(message)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0/directives/agcOnMouseout.md
+++ b/_docs/0.1.0/directives/agcOnMouseout.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
+<div google-chart chart="myChartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0/directives/agcOnReady.md
+++ b/_docs/0.1.0/directives/agcOnReady.md
@@ -8,5 +8,5 @@ latest: false
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/0.1.0/directives/agcOnSelect.html
+++ b/_docs/0.1.0/directives/agcOnSelect.html
@@ -27,7 +27,7 @@ latest: false
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="selectHandler(selectedItem)"></div>
+<div google-chart chart="myChartObject" agc-on-select="selectHandler(selectedItem)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/0.1.0/directives/googleChart.md
+++ b/_docs/0.1.0/directives/googleChart.md
@@ -20,6 +20,6 @@ for practical code examples.
         <td><p><code>chart</code></p>
         <td>expression</td>
         <td>Binding to the chart object with the values needed to build the chart.</td>
-        <td><p><code>chart="chartObject"</code></p></td>
+        <td><p><code>chart="myChartObject"</code></p></td>
     </tr>
 </table>

--- a/_docs/0.1.0/examples/annotation.html
+++ b/_docs/0.1.0/examples/annotation.html
@@ -14,11 +14,11 @@ ng-app: "google-chart-sample"
     <input type="number" ng-model="secondRow[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/annotation.js
+++ b/_docs/0.1.0/examples/annotation.js
@@ -2,7 +2,7 @@
 (function(){
     angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
     .controller("AnnotationChartCtrl", function ($scope) {
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         $scope.secondRow = [
             {v: new Date(2314, 2, 16)},
@@ -15,9 +15,9 @@
         ];
 
 
-        $scope.chartObject.type = "AnnotationChart";
+        $scope.myChartObject.type = "AnnotationChart";
 
-        $scope.chartObject.data = {"cols": [
+        $scope.myChartObject.data = {"cols": [
             {id: "month", label: "Month", type: "date"},
             {id: "kepler-data", label: "Kepler-22b mission", type: "number"},
             {id: "kepler-annot", label: "Kepler-22b Annotation Title", type: "string"},
@@ -48,7 +48,7 @@
             ]}
         ]};
 
-        $scope.chartObject.options = {
+        $scope.myChartObject.options = {
             displayAnnotations: true
         };
     });

--- a/_docs/0.1.0/examples/bar.html
+++ b/_docs/0.1.0/examples/bar.html
@@ -13,11 +13,11 @@ ng-controller: "GenericChartCtrl"
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/bar.js
+++ b/_docs/0.1.0/examples/bar.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "BarChart";
+    $scope.myChartObject.type = "BarChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0/examples/column.html
+++ b/_docs/0.1.0/examples/column.html
@@ -9,17 +9,17 @@ scripts:
 ng-app: "google-chart-sample"
 ng-controller: "GenericChartCtrl"
 ---
-<div ng-init="chartObject.type='ColumnChart'">
+<div ng-init="myChartObject.type='ColumnChart'">
 <div>
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 </div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/column.js
+++ b/_docs/0.1.0/examples/column.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "ColumnChart";
+    $scope.myChartObject.type = "ColumnChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0/examples/gauge.html
+++ b/_docs/0.1.0/examples/gauge.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "GaugeChartCtrl"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/gauge.js
+++ b/_docs/0.1.0/examples/gauge.js
@@ -4,10 +4,10 @@
   angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
   .controller("GaugeChartCtrl", function($scope) {
 
-    $scope.chartObject = {};
-    $scope.chartObject.type = "Gauge";
+    $scope.myChartObject = {};
+    $scope.myChartObject.type = "Gauge";
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
       width: 400,
       height: 120,
       redFrom: 90,
@@ -17,7 +17,7 @@
       minorTicks: 5
     };
 
-    $scope.chartObject.data = [
+    $scope.myChartObject.data = [
       ['Label', 'Value'],
       ['Memory', 80],
       ['CPU', 55],

--- a/_docs/0.1.0/examples/hide-series.html
+++ b/_docs/0.1.0/examples/hide-series.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "HideSeriesController"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 <div class="alert alert-info"><span class="fa fa-info-circle fa-lg"></span> Click a legend item to toggle a series.</div>
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/hide-series.js
+++ b/_docs/0.1.0/examples/hide-series.js
@@ -7,7 +7,7 @@
 
     function HideSeriesController($scope) {
         // Properties
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         //Methods
         $scope.hideSeries = hideSeries;
@@ -17,27 +17,27 @@
         function hideSeries(selectedItem) {
             var col = selectedItem.column;
             if (selectedItem.row === null) {
-                if ($scope.chartObject.view.columns[col] == col) {
-                    $scope.chartObject.view.columns[col] = {
-                        label: $scope.chartObject.data.cols[col].label,
-                        type: $scope.chartObject.data.cols[col].type,
+                if ($scope.myChartObject.view.columns[col] == col) {
+                    $scope.myChartObject.view.columns[col] = {
+                        label: $scope.myChartObject.data.cols[col].label,
+                        type: $scope.myChartObject.data.cols[col].type,
                         calc: function() {
                             return null;
                         }
                     };
-                    $scope.chartObject.options.colors[col - 1] = '#CCCCCC';
+                    $scope.myChartObject.options.colors[col - 1] = '#CCCCCC';
                 }
                 else {
-                    $scope.chartObject.view.columns[col] = col;
-                    $scope.chartObject.options.colors[col - 1] = $scope.chartObject.options.defaultColors[col - 1];
+                    $scope.myChartObject.view.columns[col] = col;
+                    $scope.myChartObject.options.colors[col - 1] = $scope.myChartObject.options.defaultColors[col - 1];
                 }
             }
         }
 
         function init() {
-            $scope.chartObject.type = "LineChart";
-            $scope.chartObject.displayed = false;
-            $scope.chartObject.data = {
+            $scope.myChartObject.type = "LineChart";
+            $scope.myChartObject.displayed = false;
+            $scope.myChartObject.data = {
                 "cols": [{
                     id: "month",
                     label: "Month",
@@ -102,7 +102,7 @@
                     }]
                 }]
             };
-            $scope.chartObject.options = {
+            $scope.myChartObject.options = {
                 "title": "Sales per month",
                 "colors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
                 "defaultColors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
@@ -120,7 +120,7 @@
                 }
             };
 
-            $scope.chartObject.view = {
+            $scope.myChartObject.view = {
                 columns: [0, 1, 2, 3, 4]
             };
         }

--- a/_docs/0.1.0/examples/multi-chart.html
+++ b/_docs/0.1.0/examples/multi-chart.html
@@ -80,9 +80,9 @@ ng-controller: "MultiChartCtrl"
     <div class="col-xs-12">
 
         <h2>Usage</h2>
-        <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
+        <pre ng-non-bindable>&lt;div google-chart chart="myChartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
         <h2>Setup</h2>
-        <pre>$scope.chartObject = !! chart|json:true !!</pre>
+        <pre>$scope.myChartObject = !! chart|json:true !!</pre>
 
     </div>
 </div>

--- a/_docs/0.1.0/examples/pie.html
+++ b/_docs/0.1.0/examples/pie.html
@@ -13,11 +13,11 @@ ng-controller: GenericChartCtrl
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/0.1.0/examples/pie.js
+++ b/_docs/0.1.0/examples/pie.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "PieChart";
+    $scope.myChartObject.type = "PieChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/0.1.0/services/googleChartApiPromise.md
+++ b/_docs/0.1.0/services/googleChartApiPromise.md
@@ -19,14 +19,14 @@ objects and functions related to the API will not be available.
     ExampleController.$inject = ['$scope', 'googleChartApiPromise'];
 
     function ExampleController ($scope, googleChartApiPromise){
-        $scope.chartObject = {
+        $scope.myChartObject = {
             type: 'PieChart'
         };
 
         googleChartApiPromise.then(buildDataTable);
 
         function buildDataTable(){
-            $scope.chartObject.data = new google.visualization.DataTable();
+            $scope.myChartObject.data = new google.visualization.DataTable();
             // Continue building the data table.
         }
     }

--- a/_docs/latest/directives/agcBeforeDraw.md
+++ b/_docs/latest/directives/agcBeforeDraw.md
@@ -8,5 +8,5 @@ latest: true
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-before-draw="drawHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/latest/directives/agcOnError.html
+++ b/_docs/latest/directives/agcOnError.html
@@ -22,7 +22,7 @@ latest: true
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-error="errorHandler(message)"></div>
+<div google-chart chart="myChartObject" agc-on-error="errorHandler(message)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/latest/directives/agcOnMouseout.md
+++ b/_docs/latest/directives/agcOnMouseout.md
@@ -8,5 +8,5 @@ latest: true
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
+<div google-chart chart="myChartObject" agc-on-mouseout="mouseoutHandler(row,column)"></div>
 {% endhighlight %}

--- a/_docs/latest/directives/agcOnReady.md
+++ b/_docs/latest/directives/agcOnReady.md
@@ -8,5 +8,5 @@ latest: true
 
 #### Code Example
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
+<div google-chart chart="myChartObject" agc-on-ready="readyHandler(chartWrapper)"></div>
 {% endhighlight %}

--- a/_docs/latest/directives/agcOnSelect.html
+++ b/_docs/latest/directives/agcOnSelect.html
@@ -27,7 +27,7 @@ latest: true
 
 <h2>Code Example</h2>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="selectHandler(selectedItem)"></div>
+<div google-chart chart="myChartObject" agc-on-select="selectHandler(selectedItem)"></div>
 {% endhighlight %}
 
 <h2>Available Locals</h2>

--- a/_docs/latest/directives/googleChart.md
+++ b/_docs/latest/directives/googleChart.md
@@ -20,6 +20,6 @@ for practical code examples.
         <td><p><code>chart</code></p>
         <td>expression</td>
         <td>Binding to the chart object with the values needed to build the chart.</td>
-        <td><p><code>chart="chartObject"</code></p></td>
+        <td><p><code>chart="myChartObject"</code></p></td>
     </tr>
 </table>

--- a/_docs/latest/examples/annotation.html
+++ b/_docs/latest/examples/annotation.html
@@ -14,11 +14,11 @@ ng-app: "google-chart-sample"
     <input type="number" ng-model="secondRow[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/annotation.js
+++ b/_docs/latest/examples/annotation.js
@@ -2,7 +2,7 @@
 (function(){
     angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
     .controller("AnnotationChartCtrl", function ($scope) {
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         $scope.secondRow = [
             {v: new Date(2314, 2, 16)},
@@ -15,9 +15,9 @@
         ];
 
 
-        $scope.chartObject.type = "AnnotationChart";
+        $scope.myChartObject.type = "AnnotationChart";
 
-        $scope.chartObject.data = {"cols": [
+        $scope.myChartObject.data = {"cols": [
             {id: "month", label: "Month", type: "date"},
             {id: "kepler-data", label: "Kepler-22b mission", type: "number"},
             {id: "kepler-annot", label: "Kepler-22b Annotation Title", type: "string"},
@@ -48,7 +48,7 @@
             ]}
         ]};
 
-        $scope.chartObject.options = {
+        $scope.myChartObject.options = {
             displayAnnotations: true
         };
     });

--- a/_docs/latest/examples/bar.html
+++ b/_docs/latest/examples/bar.html
@@ -13,11 +13,11 @@ ng-controller: "GenericChartCtrl"
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/bar.js
+++ b/_docs/latest/examples/bar.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "BarChart";
+    $scope.myChartObject.type = "BarChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/latest/examples/column.html
+++ b/_docs/latest/examples/column.html
@@ -9,17 +9,17 @@ scripts:
 ng-app: "google-chart-sample"
 ng-controller: "GenericChartCtrl"
 ---
-<div ng-init="chartObject.type='ColumnChart'">
+<div ng-init="myChartObject.type='ColumnChart'">
 <div>
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 </div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/column.js
+++ b/_docs/latest/examples/column.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "ColumnChart";
+    $scope.myChartObject.type = "ColumnChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/latest/examples/gauge.html
+++ b/_docs/latest/examples/gauge.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "GaugeChartCtrl"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:130px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:130px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/gauge.js
+++ b/_docs/latest/examples/gauge.js
@@ -4,10 +4,10 @@
   angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
   .controller("GaugeChartCtrl", function($scope) {
 
-    $scope.chartObject = {};
-    $scope.chartObject.type = "Gauge";
+    $scope.myChartObject = {};
+    $scope.myChartObject.type = "Gauge";
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
       width: 400,
       height: 120,
       redFrom: 90,
@@ -17,7 +17,7 @@
       minorTicks: 5
     };
 
-    $scope.chartObject.data = [
+    $scope.myChartObject.data = [
       ['Label', 'Value'],
       ['Memory', 80],
       ['CPU', 55],

--- a/_docs/latest/examples/hide-series.html
+++ b/_docs/latest/examples/hide-series.html
@@ -9,11 +9,11 @@ scripts:
 ng-controller: "HideSeriesController"
 ng-app: "google-chart-sample"
 ---
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 <div class="alert alert-info"><span class="fa fa-info-circle fa-lg"></span> Click a legend item to toggle a series.</div>
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
+<div google-chart chart="myChartObject" agc-on-select="hideSeries(selectedItem)" style="height:450px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/hide-series.js
+++ b/_docs/latest/examples/hide-series.js
@@ -7,7 +7,7 @@
 
     function HideSeriesController($scope) {
         // Properties
-        $scope.chartObject = {};
+        $scope.myChartObject = {};
 
         //Methods
         $scope.hideSeries = hideSeries;
@@ -17,27 +17,27 @@
         function hideSeries(selectedItem) {
             var col = selectedItem.column;
             if (selectedItem.row === null) {
-                if ($scope.chartObject.view.columns[col] == col) {
-                    $scope.chartObject.view.columns[col] = {
-                        label: $scope.chartObject.data.cols[col].label,
-                        type: $scope.chartObject.data.cols[col].type,
+                if ($scope.myChartObject.view.columns[col] == col) {
+                    $scope.myChartObject.view.columns[col] = {
+                        label: $scope.myChartObject.data.cols[col].label,
+                        type: $scope.myChartObject.data.cols[col].type,
                         calc: function() {
                             return null;
                         }
                     };
-                    $scope.chartObject.options.colors[col - 1] = '#CCCCCC';
+                    $scope.myChartObject.options.colors[col - 1] = '#CCCCCC';
                 }
                 else {
-                    $scope.chartObject.view.columns[col] = col;
-                    $scope.chartObject.options.colors[col - 1] = $scope.chartObject.options.defaultColors[col - 1];
+                    $scope.myChartObject.view.columns[col] = col;
+                    $scope.myChartObject.options.colors[col - 1] = $scope.myChartObject.options.defaultColors[col - 1];
                 }
             }
         }
 
         function init() {
-            $scope.chartObject.type = "LineChart";
-            $scope.chartObject.displayed = false;
-            $scope.chartObject.data = {
+            $scope.myChartObject.type = "LineChart";
+            $scope.myChartObject.displayed = false;
+            $scope.myChartObject.data = {
                 "cols": [{
                     id: "month",
                     label: "Month",
@@ -102,7 +102,7 @@
                     }]
                 }]
             };
-            $scope.chartObject.options = {
+            $scope.myChartObject.options = {
                 "title": "Sales per month",
                 "colors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
                 "defaultColors": ['#0000FF', '#009900', '#CC0000', '#DD9900'],
@@ -120,7 +120,7 @@
                 }
             };
 
-            $scope.chartObject.view = {
+            $scope.myChartObject.view = {
                 columns: [0, 1, 2, 3, 4]
             };
         }

--- a/_docs/latest/examples/multi-chart.html
+++ b/_docs/latest/examples/multi-chart.html
@@ -80,9 +80,9 @@ ng-controller: "MultiChartCtrl"
     <div class="col-xs-12">
 
         <h2>Usage</h2>
-        <pre ng-non-bindable>&lt;div google-chart chart="chartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
+        <pre ng-non-bindable>&lt;div google-chart chart="myChartObject" style="{{ "{{cssStyle"}}}}"&gt;&lt;/div&gt;</pre>
         <h2>Setup</h2>
-        <pre>$scope.chartObject = !! chart|json:true !!</pre>
+        <pre>$scope.myChartObject = !! chart|json:true !!</pre>
 
     </div>
 </div>

--- a/_docs/latest/examples/pie.html
+++ b/_docs/latest/examples/pie.html
@@ -13,11 +13,11 @@ ng-controller: GenericChartCtrl
     Onions: <input type="number" ng-model="onions[1].v" />
 </div>
 
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 
 <h4>HTML Template</h4>
 {% highlight html %}
-<div google-chart chart="chartObject" style="height:600px; width:100%;"></div>
+<div google-chart chart="myChartObject" style="height:600px; width:100%;"></div>
 {% endhighlight %}
 
 <h4>JavaScript</h4>

--- a/_docs/latest/examples/pie.js
+++ b/_docs/latest/examples/pie.js
@@ -1,16 +1,16 @@
 /* global angular */
 angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
 .controller("GenericChartCtrl", function ($scope) {
-    $scope.chartObject = {};
+    $scope.myChartObject = {};
     
-    $scope.chartObject.type = "PieChart";
+    $scope.myChartObject.type = "PieChart";
     
     $scope.onions = [
         {v: "Onions"},
         {v: 3},
     ];
 
-    $scope.chartObject.data = {"cols": [
+    $scope.myChartObject.data = {"cols": [
         {id: "t", label: "Topping", type: "string"},
         {id: "s", label: "Slices", type: "number"}
     ], "rows": [
@@ -33,7 +33,7 @@ angular.module("google-chart-sample", ["googlechart", "googlechart-docs"])
         ]}
     ]};
 
-    $scope.chartObject.options = {
+    $scope.myChartObject.options = {
         'title': 'How Much Pizza I Ate Last Night'
     };
 });

--- a/_docs/latest/services/googleChartApiPromise.md
+++ b/_docs/latest/services/googleChartApiPromise.md
@@ -19,14 +19,14 @@ objects and functions related to the API will not be available.
     ExampleController.$inject = ['$scope', 'googleChartApiPromise'];
 
     function ExampleController ($scope, googleChartApiPromise){
-        $scope.chartObject = {
+        $scope.myChartObject = {
             type: 'PieChart'
         };
 
         googleChartApiPromise.then(buildDataTable);
 
         function buildDataTable(){
-            $scope.chartObject.data = new google.visualization.DataTable();
+            $scope.myChartObject.data = new google.visualization.DataTable();
             // Continue building the data table.
         }
     }


### PR DESCRIPTION
This is the result of a gitter conversation. From what I can gather, a simple text replace was all that was required.  If other variable names could use similar updates (my glance didn't catch any) I can update this pull request I believe.