### PR TITLE
PhantomJS 1.3.8 bug fixed

### DIFF
--- a/src/agcNullLoader.js
+++ b/src/agcNullLoader.js
@@ -10,14 +10,16 @@
     function AgcNullLoaderProvider(){
         this._hasTrigger = false;
         this._libraryOverride = null;
-        this._triggerFunction = (function(){
-            // If the trigger function is called before $get,
-            // just act as if it was never fetched.
-            if (this._deferred)
-                this._deferred.resolve(this._libraryOverride || google);
-            else
-                this._hasTrigger = false;
-        }).bind(this);
+        if(this._triggerFunction != null && this._triggerFunction != undefined){
+           this._triggerFunction = (function(){
+                // If the trigger function is called before $get,
+                // just act as if it was never fetched.
+                if (this._deferred)
+                    this._deferred.resolve(this._libraryOverride || google);
+                else
+                    this._hasTrigger = false;
+            }).bind(this);
+        }  
         this._deferred = null;
     }
 


### PR DESCRIPTION
In phantomJs 1.3.8 there is an error of injection of the module because it is property is null when loading and therefore can not execute the bind method.